### PR TITLE
Version '1.4.1' - Currency and CurrentBalance related updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library is designed for both Java 8+ and Android.
 
 ## How to include
 ```
-    implementation "com.datameshgroup.fusion:fusion-sdk:1.4.0"
+    implementation "com.datameshgroup.fusion:fusion-sdk:1.4.1"
 ```
 If you are using Android you will need to add Java 8 syntax desugaring.
 In your app's build.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group 'com.datameshgroup.fusion'
 // Update Message.FUSION_SATELLITE_VERSION when you update this
-version '1.4.0'
+version '1.4.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/au/com/dmg/fusion/Message.java
+++ b/src/main/java/au/com/dmg/fusion/Message.java
@@ -46,7 +46,7 @@ public class Message implements Serializable {
     private SaleToPOIResponse response = null;
     @Json(name = "FusionSatelliteLibraryVersion")
 
-    public static String FUSION_SATELLITE_VERSION = "1.4.0";
+    public static String FUSION_SATELLITE_VERSION = "1.4.1";
 
     public static String AXISPAY_PACKAGE_NAME = "au.com.dmg.axispay";
     public static String AXISPAY_LAUNCH = "au.com.dmg.axispay" + ".MainActivity";

--- a/src/main/java/au/com/dmg/fusion/response/balanceinquiryresponse/PaymentAccountStatus.java
+++ b/src/main/java/au/com/dmg/fusion/response/balanceinquiryresponse/PaymentAccountStatus.java
@@ -3,6 +3,7 @@ package au.com.dmg.fusion.response.balanceinquiryresponse;
 import au.com.dmg.fusion.response.paymentresponse.PaymentAcquirerData;
 import au.com.dmg.fusion.response.paymentresponse.PaymentInstrumentData;
 import com.squareup.moshi.Json;
+import org.jetbrains.annotations.Nullable;
 
 import java.math.BigDecimal;
 
@@ -17,8 +18,13 @@ public class PaymentAccountStatus {
     private final PaymentAcquirerData paymentAcquirerData;
 
     public PaymentInstrumentData getPaymentInstrumentData() { return  paymentInstrumentData; }
+
+    @Nullable
     public String getCurrency(){ return currency; }
+
+    @Nullable
     public BigDecimal getCurrentBalance() { return currentBalance; }
+
     public PaymentAcquirerData getPaymentAcquirerData() { return paymentAcquirerData; }
 
     public static class Builder {
@@ -54,16 +60,6 @@ public class PaymentAccountStatus {
             return Builder.this;
         }
         public PaymentAccountStatus build() {
-            if(this.currentBalance==null){
-                throw new NullPointerException("The property \"currentBalance\" is null. "
-                        + "Please set the value by \"currentBalance()\". "
-                        + "The property \"currentBalance\" is required.");
-            }
-            if(this.currency==null || this.currency.isEmpty()){
-                throw new NullPointerException("The property \"currency\" is null or empty. "
-                        + "Please set the value by \"currency()\". "
-                        + "The property \"currency\" is required.");
-            }
             if(this.paymentInstrumentData != null){
                 if(this.paymentInstrumentData.getCardData().getEntryMode() == null){
                     throw new NullPointerException("The property \"entryMode\" is null. "

--- a/src/main/java/au/com/dmg/fusion/response/paymentresponse/PaymentResult.java
+++ b/src/main/java/au/com/dmg/fusion/response/paymentresponse/PaymentResult.java
@@ -27,6 +27,8 @@ import au.com.dmg.fusion.data.PaymentType;
 import com.squareup.moshi.Json;
 import org.jetbrains.annotations.Nullable;
 
+import java.math.BigDecimal;
+
 public class PaymentResult {
 
     @Json(name = "PaymentType")
@@ -41,6 +43,10 @@ public class PaymentResult {
     private final PaymentAcquirerData paymentAcquirerData;
     @Json(name = "SplitPaymentFlag")
     private final Boolean splitPaymentFlag;
+    @Json(name = "Currency")
+    private final String currency;
+    @Json(name = "CurrentBalance")
+    private final BigDecimal currentBalance;
 
     @Nullable
     public PaymentType getPaymentType() {
@@ -70,6 +76,12 @@ public class PaymentResult {
     @Nullable
     public Boolean getSplitPaymentFlag(){ return splitPaymentFlag; }
 
+    @Nullable
+    public String getCurrency(){ return currency; }
+
+    @Nullable
+    public BigDecimal getCurrentBalance() { return currentBalance; }
+
     public static class Builder {
 
         private PaymentType paymentType;
@@ -78,6 +90,8 @@ public class PaymentResult {
         private Boolean onlineFlag;
         private PaymentAcquirerData paymentAcquirerData;
         private Boolean splitPaymentFlag = false;
+        private String currency = null;
+        private BigDecimal currentBalance = null;
 
         public Builder() {
         }
@@ -97,6 +111,27 @@ public class PaymentResult {
             this.onlineFlag = onlineFlag;
             this.paymentAcquirerData = paymentAcquirerData;
             this.splitPaymentFlag = splitPaymentFlag;
+        }
+
+        Builder(PaymentType paymentType, PaymentInstrumentData paymentInstrumentData, AmountsResp amountsResp, Boolean onlineFlag, PaymentAcquirerData paymentAcquirerData, String currency, BigDecimal currentBalance) {
+            this.paymentType = paymentType;
+            this.paymentInstrumentData = paymentInstrumentData;
+            this.amountsResp = amountsResp;
+            this.onlineFlag = onlineFlag;
+            this.paymentAcquirerData = paymentAcquirerData;
+            this.currency = currency;
+            this.currentBalance = currentBalance;
+        }
+
+        Builder(PaymentType paymentType, PaymentInstrumentData paymentInstrumentData, AmountsResp amountsResp, Boolean onlineFlag, PaymentAcquirerData paymentAcquirerData, Boolean splitPaymentFlag, String currency, BigDecimal currentBalance) {
+            this.paymentType = paymentType;
+            this.paymentInstrumentData = paymentInstrumentData;
+            this.amountsResp = amountsResp;
+            this.onlineFlag = onlineFlag;
+            this.paymentAcquirerData = paymentAcquirerData;
+            this.splitPaymentFlag = splitPaymentFlag;
+            this.currency = currency;
+            this.currentBalance = currentBalance;
         }
 
         public Builder paymentType(PaymentType paymentType) {
@@ -129,6 +164,16 @@ public class PaymentResult {
             return Builder.this;
         }
 
+        public Builder currency(String currency){
+            this.currency = currency;
+            return Builder.this;
+        }
+
+        public Builder currentBalance(BigDecimal currentBalance){
+            this.currentBalance = currentBalance;
+            return Builder.this;
+        }
+
         public PaymentResult build() {
             if (this.onlineFlag == null) {
                 throw new NullPointerException("The property \"onlineFlag\" is null. "
@@ -147,6 +192,8 @@ public class PaymentResult {
         this.onlineFlag = builder.onlineFlag;
         this.paymentAcquirerData = builder.paymentAcquirerData;
         this.splitPaymentFlag = builder.splitPaymentFlag;
+        this.currency = builder.currency;
+        this.currentBalance = builder.currentBalance;
     }
 }
 
@@ -159,4 +206,6 @@ PaymentInstrumentData paymentInstrumentData
 AmountsResp amountsResp
 @Required Boolean onlineFlag
 PaymentAcquirerData paymentAcquirerData
+String currency
+BigDecimal currentBalance
 * */

--- a/src/test/java/au/com/dmg/fusion/response/BalanceInquiryResponseTest.java
+++ b/src/test/java/au/com/dmg/fusion/response/BalanceInquiryResponseTest.java
@@ -269,46 +269,5 @@ public class BalanceInquiryResponseTest extends TestCase {
         assertEquals("The property \"storedValueAccountType\" is null. "
                 + "Please set the value by \"storedValueAccountType()\" under StoredValueAccountID. "
                 + "The properties \"storedValueAccountType\", \"identificationType\", and \"storedValueID\" are required.", exceptionStoredValueAccountType.getMessage());
-
-        NullPointerException exceptionCurrency =
-                assertThrows(NullPointerException.class,
-                        () -> new BalanceInquiryResponse.Builder()
-                                .response(successResponse)
-                                .paymentAccountStatus(new PaymentAccountStatus.Builder()
-                                        .paymentInstrumentData(new PaymentInstrumentData.Builder()
-                                                .paymentInstrumentType(PaymentInstrumentType.Card)
-                                                .cardData(validCardData)
-                                                .storedValueAccountID(validStoredValueAccountID)
-                                                .build())
-                                        .currentBalance(new BigDecimal(100))
-                                        .paymentAcquirerData(validPaymentAcquirerData)
-                                        .build())
-                                .paymentReceipt(validPaymentReceipt)
-                                .build());
-        System.out.println("BalanceInquiryResponseTest - testBalanceInquiryResponseNulls - exceptionCurrency");
-        assertEquals("The property \"currency\" is null or empty. "
-                + "Please set the value by \"currency()\". "
-                + "The property \"currency\" is required.", exceptionCurrency.getMessage());
-
-        NullPointerException exceptionCurrentBalance =
-                assertThrows(NullPointerException.class,
-                        () -> new BalanceInquiryResponse.Builder()
-                                .response(successResponse)
-                                .paymentAccountStatus(new PaymentAccountStatus.Builder()
-                                        .paymentInstrumentData(new PaymentInstrumentData.Builder()
-                                                .paymentInstrumentType(PaymentInstrumentType.Card)
-                                                .cardData(validCardData)
-                                                .storedValueAccountID(validStoredValueAccountID)
-                                                .build())
-                                        .currency("AUD")
-                                        .paymentAcquirerData(validPaymentAcquirerData)
-                                        .build())
-                                .paymentReceipt(validPaymentReceipt)
-                                .build());
-        System.out.println("BalanceInquiryResponseTest - testBalanceInquiryResponseNulls - currentBalance");
-        assertEquals("The property \"currentBalance\" is null. "
-                + "Please set the value by \"currentBalance()\". "
-                + "The property \"currentBalance\" is required.", exceptionCurrentBalance.getMessage());
-
     }
 }


### PR DESCRIPTION
Version '1.4.1' - Allow Currency and CurrentBalance to be null for PaymentAccountStatus in case the processor doesn't return these values - even if Balance Inquiry has been approved.  Added Currency and CurrentBalance under PaymentResult - used to store Balance returned by the Processor for certain cards (e.g. Gift Cards) used for Purchase.